### PR TITLE
Re-enable disabled dataguard configurations on set-up

### DIFF
--- a/files/setup_primary_dgbroker.sh
+++ b/files/setup_primary_dgbroker.sh
@@ -149,6 +149,13 @@ else
     then
       MATCH=1
       info "${standbydb} already configured in dgbroker"
+      dgmgrl /  "show configuration" | grep "Physical standby database"  | grep ${standbydb} | grep "(disabled)" > /dev/null
+      DG_DISABLED=$?
+      if [ $DG_DISABLED -eq 0 ];
+      then
+         info "${standbydb} configuration is disabled - re-enabling"
+         dgmgrl /  "enable database ${standbydb}" 
+      fi
       break
     fi
   done


### PR DESCRIPTION
If there is a failure of HA build, the dataguard configuration may exist but is left in a disabled state.   Re-enable the config if we run the HA build again.